### PR TITLE
Improve game tiles using opacity and rotation

### DIFF
--- a/app/assets/stylesheets/game_pieces.css.erb
+++ b/app/assets/stylesheets/game_pieces.css.erb
@@ -4,6 +4,8 @@
   padding-top: <%=(0.15 * base_size).floor%>px;
   width: 100%;
   height: 100%;
+  position: relative;
+  z-index: 2;
 }
 
 .game-piece-person.ninja {

--- a/app/assets/stylesheets/game_tiles.css.erb
+++ b/app/assets/stylesheets/game_tiles.css.erb
@@ -1,64 +1,55 @@
-.game-tile-background-default {
+.hex-tile::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  z-index: 1; /* Ensure it is below the game piece */
+  opacity: 0.6;
+}
+
+.bg-default {
   background-color: #777;
 }
 
-.game-tile-background-grass::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-size: cover;
-  background-position: center;
-  opacity: 0.5;
-  z-index: 1; /* Ensure it is below the game piece */
+.bg-grass::before {
   background-image: url(<%= asset_path('grass.jpg') %>);
 }
 
-.game-tile-background-rocks::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-size: cover;
-  background-position: center;
-  opacity: 0.5;
-  z-index: 1; /* Ensure it is below the game piece */
+.bg-rocks::before {
   background-image: url(<%= asset_path('rocky.jpg') %>);
 }
 
-.game-tile-background-dirt::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-size: cover;
-  background-position: center;
-  opacity: 0.5;
-  z-index: 1; /* Ensure it is below the game piece */
+.bg-dirt::before {
   background-image: url(<%= asset_path('dirt.jpg') %>);
 }
 
-.game-tile-background-water::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-size: cover;
-  background-position: center;
-  opacity: 0.5;
-  z-index: 1; /* Ensure it is below the game piece */
+.bg-water::before {
   background-image: url(<%= asset_path('water.jpg') %>);
   opacity: 0.8;
 }
 
-.game-tile-background-nothing {
+.bg-nothing {
   background-image: none;
+}
+
+.r-0::before {
+  background-position: center;
+}
+.r-1::before {
+  background-position: bottom left;
+}
+.r-2::before {
+  background-position: bottom right;
+}
+.r-3::before {
+  background-position: top right;
+}
+.r-4::before {
+  background-position: top left;
+}
+.r-5::before {
+  background-position: top center;
 }

--- a/app/assets/stylesheets/game_tiles.css.erb
+++ b/app/assets/stylesheets/game_tiles.css.erb
@@ -2,20 +2,61 @@
   background-color: #777;
 }
 
-.game-tile-background-grass {
+.game-tile-background-grass::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  opacity: 0.5;
+  z-index: 1; /* Ensure it is below the game piece */
   background-image: url(<%= asset_path('grass.jpg') %>);
 }
 
-.game-tile-background-rocks {
+.game-tile-background-rocks::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  opacity: 0.5;
+  z-index: 1; /* Ensure it is below the game piece */
   background-image: url(<%= asset_path('rocky.jpg') %>);
 }
 
-.game-tile-background-dirt {
+.game-tile-background-dirt::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  opacity: 0.5;
+  z-index: 1; /* Ensure it is below the game piece */
   background-image: url(<%= asset_path('dirt.jpg') %>);
 }
 
-.game-tile-background-water {
+.game-tile-background-water::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  opacity: 0.5;
+  z-index: 1; /* Ensure it is below the game piece */
   background-image: url(<%= asset_path('water.jpg') %>);
+  opacity: 0.8;
 }
 
 .game-tile-background-nothing {

--- a/app/assets/stylesheets/hexagon.css.erb
+++ b/app/assets/stylesheets/hexagon.css.erb
@@ -41,7 +41,6 @@
     margin-left: <%= (0.5 * base_size).floor %>px;
 }
 
-
 .game-tile .inner-hex {
     width: <%= base_size %>px;
     height: <%= (short_side * 2).floor %>px;

--- a/app/models/game_tile.rb
+++ b/app/models/game_tile.rb
@@ -5,6 +5,7 @@
 #  id            :bigint           not null, primary key
 #  background    :string
 #  column        :integer
+#  rotation      :integer          default(0)
 #  row           :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -34,7 +35,13 @@ class GameTile < ApplicationRecord
     rows.times do |row_number|
       # if a row or column exists, it will just be false
       columns.times do |column_number|
-        tile = GameTile.create(row: row_number, column: column_number, game_board: board, background: ['rocks', 'grass', 'grass', 'dirt', 'water'].sample)
+        tile = GameTile.create(
+          row: row_number,
+          column: column_number,
+          rotation: rand(0..5),
+          game_board: board,
+          background: ['rocks', 'grass', 'grass', 'dirt', 'water'].sample,
+        )
         Rails.logger.info "Tile: #{tile.errors.full_messages}" unless tile.valid?
       end
     end

--- a/app/views/game_tiles/_game_tile.html.erb
+++ b/app/views/game_tiles/_game_tile.html.erb
@@ -5,7 +5,7 @@
 %>
   <div  class="hex inner-hex">
     <div class="hex-in1">
-      <div class="hex-in2 hex-area game-tile-background-<%= game_tile.background %>">
+      <div class="hex-in2 hex-area hex-tile r-<%=game_tile.rotation %> bg-<%= game_tile.background %>">
         <%= render(game_tile.game_piece) unless game_tile.empty? %>
       </div>
     </div>

--- a/db/migrate/20240715175114_add_rotation_to_game_tile.rb
+++ b/db/migrate/20240715175114_add_rotation_to_game_tile.rb
@@ -1,0 +1,5 @@
+class AddRotationToGameTile < ActiveRecord::Migration[7.0]
+  def change
+    add_column :game_tiles, :rotation, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_24_023319) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_15_175114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_24_023319) do
     t.datetime "updated_at", null: false
     t.bigint "game_board_id"
     t.string "background"
+    t.integer "rotation", default: 0
     t.index ["game_board_id"], name: "index_game_tiles_on_game_board_id"
     t.index ["game_piece_id"], name: "index_game_tiles_on_game_piece_id"
   end

--- a/test/fixtures/game_tiles.yml
+++ b/test/fixtures/game_tiles.yml
@@ -5,6 +5,7 @@
 #  id            :bigint           not null, primary key
 #  background    :string
 #  column        :integer
+#  rotation      :integer          default(0)
 #  row           :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/test/models/game_tile_test.rb
+++ b/test/models/game_tile_test.rb
@@ -5,6 +5,7 @@
 #  id            :bigint           not null, primary key
 #  background    :string
 #  column        :integer
+#  rotation      :integer          default(0)
 #  row           :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null


### PR DESCRIPTION
## What

The goal here is to improve the game tiles by adding rotation and opacity.

## Why

The tiles are too similar so the repeating texture doesn't look pleasing

## How

Initially the thought was that if the background could rotate, it would help the tiles have a sort of variability that would allow them to look different and blend together.

My initial attempt at rotating the tile caused the whole tile to rotate and weird stuff to happen. I ended up just adding opacity to the background image and it's definitely a lot better. Having a more faded background makes the player stand out more and the tiles blend a lot more nicely.

## Things I learned

- my CSS-fu is pretty bad. It's been a long time since I did a lot of CSS
- controlling the CSS from the HTML is tricky. Maybe working with tailwind has spoiled me. I like the idea of just being able to rotate the background image with a simple control. I guess maybe using a class like `r-6` to rotate 1/6th of the way around would be good?
- maybe I want to use classes like `hex-tile r-6 bg-dirt` 

## Rotating backgrounds doesn't work

Trying to rotate the backgrounds causes something weird with the way they're cropped. Some better alternatives are:

1. Make the backgrounds more like a sprite sheet and then pick the variant with the r value.
2. Have separate assets for each variant. That's probably dumb though because we'll end up loading a lot of separate image files.

<img width="862" alt="Screenshot 2024-07-15 at 11 48 45 AM" src="https://github.com/user-attachments/assets/46ef1933-3c25-404c-8700-44e1cdfd44b6">

<img width="869" alt="Screenshot 2024-07-15 at 11 49 00 AM" src="https://github.com/user-attachments/assets/1eb59a59-45f2-4730-a238-6f241aaa6592">


